### PR TITLE
fix: Address 4 bugs from PR #1 code review

### DIFF
--- a/packages/react/src/components/chat-input.tsx
+++ b/packages/react/src/components/chat-input.tsx
@@ -63,6 +63,7 @@ export function ChatInput({
         <button
           onClick={handleSubmit}
           disabled={!value.trim() || state.isStreaming}
+          type="button"
           className="wingman-chat-input-button"
           aria-label="Send message"
         >

--- a/packages/react/src/components/thinking-block.tsx
+++ b/packages/react/src/components/thinking-block.tsx
@@ -23,6 +23,7 @@ export function ThinkingBlock({
     <div className={`wingman-thinking ${className}`}>
       <button
         className="wingman-thinking-toggle"
+        type="button"
         onClick={() => setIsOpen(!isOpen)}
         aria-expanded={isOpen}
       >

--- a/packages/react/src/components/welcome-screen.tsx
+++ b/packages/react/src/components/welcome-screen.tsx
@@ -43,6 +43,7 @@ export function WelcomeScreen({
           {suggestions.map((suggestion, i) => (
             <button
               key={i}
+              type="button"
               className="wingman-welcome-suggestion"
               onClick={() => onSuggestionClick?.(suggestion)}
             >

--- a/packages/react/src/providers/chat-provider.tsx
+++ b/packages/react/src/providers/chat-provider.tsx
@@ -48,6 +48,7 @@ const initialState: ChatState = {
 type ChatAction =
   | { type: 'ADD_USER_MESSAGE'; content: string }
   | { type: 'START_STREAMING' }
+  | { type: 'STOP_STREAMING' }
   | { type: 'APPEND_DELTA'; content: string }
   | { type: 'APPEND_REASONING'; content: string }
   | { type: 'SET_REASONING_VISIBLE'; visible: boolean }
@@ -211,6 +212,9 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
     case 'SET_ERROR':
       return { ...state, error: action.message, isStreaming: false };
 
+    case 'STOP_STREAMING':
+      return { ...state, isStreaming: false };
+
     case 'CLEAR_ERROR':
       return { ...state, error: null };
 
@@ -335,6 +339,10 @@ export function ChatProvider({ children, apiUrl = '', theme, colors, className }
           type: 'SET_ERROR',
           message: err instanceof Error ? err.message : String(err),
         });
+      } finally {
+        // Always exit streaming state, even if the SSE stream ends
+        // without a 'done' event (network drop, server crash, etc.)
+        dispatch({ type: 'STOP_STREAMING' });
       }
     },
     [apiUrl, state.sessionId, state.isStreaming],

--- a/packages/wingman/package.json
+++ b/packages/wingman/package.json
@@ -55,7 +55,7 @@
     "@github/copilot-sdk": "*"
   },
   "devDependencies": {
-    "@types/express": "^5.0.0",
+    "@types/express": "^4.17.21",
     "@types/node": "^22.0.0",
     "@types/supertest": "^7.2.0",
     "supertest": "^7.2.2",

--- a/packages/wingman/src/server.ts
+++ b/packages/wingman/src/server.ts
@@ -123,7 +123,9 @@ export function createServer(options: CreateServerOptions = {}): ServerInstance 
     };
 
     // Request timeout: must exceed SDK's 300s so SDK error fires first
-    const REQUEST_TIMEOUT = parseInt(process.env.REQUEST_TIMEOUT ?? '330000', 10);
+    const DEFAULT_TIMEOUT = 330_000;
+    const parsed = parseInt(process.env.REQUEST_TIMEOUT ?? '', 10);
+    const REQUEST_TIMEOUT = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TIMEOUT;
     const timeout = setTimeout(() => {
       if (!closed) {
         send('error', { message: 'Request timeout exceeded' });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         version: 4.8.3
     devDependencies:
       '@types/express':
-        specifier: ^5.0.0
-        version: 5.0.6
+        specifier: ^4.17.21
+        version: 4.17.25
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
@@ -611,8 +611,14 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@4.19.8':
+    resolution: {integrity: sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==}
+
   '@types/express-serve-static-core@5.1.1':
     resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@4.17.25':
+    resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
 
   '@types/express@5.0.6':
     resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
@@ -628,6 +634,9 @@ packages:
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
+
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -652,8 +661,14 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/send@0.17.6':
+    resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
+
   '@types/send@1.2.1':
     resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@1.15.10':
+    resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
@@ -2002,12 +2017,26 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/express-serve-static-core@4.19.8':
+    dependencies:
+      '@types/node': 22.19.15
+      '@types/qs': 6.15.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
   '@types/express-serve-static-core@5.1.1':
     dependencies:
       '@types/node': 22.19.15
       '@types/qs': 6.15.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
+
+  '@types/express@4.17.25':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 4.19.8
+      '@types/qs': 6.15.0
+      '@types/serve-static': 1.15.10
 
   '@types/express@5.0.6':
     dependencies:
@@ -2026,6 +2055,8 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/methods@1.1.4': {}
+
+  '@types/mime@1.3.5': {}
 
   '@types/ms@2.1.0': {}
 
@@ -2050,9 +2081,20 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/send@0.17.6':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 22.19.15
+
   '@types/send@1.2.1':
     dependencies:
       '@types/node': 22.19.15
+
+  '@types/serve-static@1.15.10':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 22.19.15
+      '@types/send': 0.17.6
 
   '@types/serve-static@2.2.0':
     dependencies:


### PR DESCRIPTION
## Summary

Fix 4 genuine bugs identified during PR #1 code review.

## Changes

### Buttons missing `type="button"` (PR1-09/10/11)
- `welcome-screen.tsx`: Added `type="button"` to suggestion buttons
- `thinking-block.tsx`: Added `type="button"` to toggle button
- `chat-input.tsx`: Added `type="button"` to send button

Without explicit `type="button"`, HTML defaults to `type="submit"`, which triggers unintended form submission if these components are rendered inside a `<form>`.

### `@types/express` v5 to v4 (PR1-14)
- Pinned `@types/express` to `^4.17.21` to match Express v4 runtime
- v5 types have different `Request`/`Response`/middleware signatures that don't match the v4 API we use

### `isStreaming` stuck on unexpected SSE close (PR1-17)
- Added `STOP_STREAMING` reducer action
- Added `finally` block in `sendMessage` to always reset `isStreaming`
- Previously, if the SSE stream ended without a `done` event (network drop, server crash), `isStreaming` would stay `true` forever, freezing the UI

### `REQUEST_TIMEOUT` NaN guard (PR1-20)
- `parseInt()` returns `NaN` if `REQUEST_TIMEOUT` env var is non-numeric
- `setTimeout(callback, NaN)` fires immediately, killing every request
- Now validates with `Number.isFinite()` and falls back to 330s default

## Testing

- All 92 wingman tests pass
- All 12 react tests pass
- All 4 packages build clean
