### PR TITLE
fix(ci): add publishConfig for public npm access

### DIFF
--- a/.changeset/fix-publish-access.md
+++ b/.changeset/fix-publish-access.md
@@ -1,0 +1,6 @@
+---
+"@wingmanjs/core": patch
+"@wingmanjs/react": patch
+---
+
+Add publishConfig with public access for scoped packages

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,6 +25,9 @@
     "test": "vitest run",
     "prepublishOnly": "npm run build"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "copilot",
     "github",

--- a/packages/wingman/package.json
+++ b/packages/wingman/package.json
@@ -27,6 +27,9 @@
     "test": "vitest run --exclude src/__tests__/server.test.ts",
     "prepublishOnly": "npm run build"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "copilot",
     "github",


### PR DESCRIPTION
## Summary

Fix scoped packages (`@wingmanjs/core`, `@wingmanjs/react`) failing to publish publicly on npm.

## Problem

The 0.1.0 publish succeeded for `create-wingman-app` but the scoped packages returned 403 — npm defaults scoped packages to **private**, and the free org plan doesn't support that.

## Fix

Added `publishConfig.access: "public"` to both scoped package.json files. This is the most reliable way to ensure public access (more reliable than the changesets config alone).

Also includes a changeset to bump versions to `0.1.1` since `0.1.0` tags already exist.

## Files Changed

- `packages/wingman/package.json` — added `publishConfig`
- `packages/react/package.json` — added `publishConfig`
- `.changeset/fix-publish-access.md` — patch bump for both packages
