### PR TITLE
fix: populate skillDirectories from plugin discovery

### DIFF
--- a/packages/wingman/src/client.ts
+++ b/packages/wingman/src/client.ts
@@ -41,9 +41,12 @@ export class WingmanClient {
   private client: CopilotClient | null = null;
   private config: Required<WingmanConfig>;
   private telemetry: ReturnType<typeof createTracer>;
+  /** Original user-provided skill directories (immutable). */
+  private readonly userSkillDirectories: string[];
 
   constructor(options: WingmanClientOptions = {}) {
     this.config = resolveConfig(options.config ?? {});
+    this.userSkillDirectories = [...this.config.skillDirectories];
     this.telemetry = createTracer(this.config.telemetry);
   }
 
@@ -165,11 +168,8 @@ export class WingmanClient {
   private async buildMCPServers() {
     const result = await discoverWithDiagnostics(this.config.mcpServers);
 
-    // Merge discovered skill directories with user-provided ones
-    if (result.skillDirectories.length > 0) {
-      const userSkills = this.config.skillDirectories ?? [];
-      this.config.skillDirectories = [...new Set([...result.skillDirectories, ...userSkills])];
-    }
+    // Always recompute from (fresh discovery) + (original user dirs) — never accumulate stale paths
+    this.config.skillDirectories = [...new Set([...result.skillDirectories, ...this.userSkillDirectories])];
 
     return result.servers;
   }


### PR DESCRIPTION
## Summary

Fix skill/agent discovery so that apps consuming wingman actually get skills from installed Copilot CLI plugins.

## Problem

`WingmanClient.buildMCPServers()` called `discoverMCPServers()` which returns only MCP server configs — it silently discards the `skillDirectories` found during plugin scanning. This means `skillDirectories` in the SDK session config was always `[]`, even though plugins like MSX-MCP and SPT-IQ have `skills/` directories with 16+ skills.

## Fix

Switch `buildMCPServers()` from `discoverMCPServers()` to `discoverWithDiagnostics()`, which returns both servers and skill directories. Merge discovered skill dirs with any user-provided ones (deduped via Set).

## Before/After

```
Before: skillDirectories = []      (always empty)
After:  skillDirectories = [
  "~/.copilot/installed-plugins/_direct/mcaps-microsoft--MSX-MCP/skills/",
  "~/.copilot/installed-plugins/_direct/mcaps-microsoft--SPT-IQ/skills/"
]
```

## Testing

128 tests pass. Verified via debug logging in clippy-sales that skill directories are now populated.
