### PR TITLE
fix: unwrap nested mcpServers, set CWD for plugin stdio servers, default tools field

### DIFF
--- a/packages/wingman/src/mcp.ts
+++ b/packages/wingman/src/mcp.ts
@@ -119,15 +119,34 @@ async function loadPluginServers(): Promise<{
           let pluginServers: Record<string, MCPServerConfig> = {};
 
           if (typeof pluginJson.mcpServers === 'string') {
-            // External file reference
+            // External file reference (e.g., ".mcp.json")
             const externalPath = join(pluginPath, pluginJson.mcpServers);
-            const external = await readJson<Record<string, MCPServerConfig>>(externalPath);
-            if (external) pluginServers = external;
+            const external = await readJson<Record<string, unknown>>(externalPath);
+            if (external) {
+              // Handle both formats:
+              // 1. Flat: { "server-name": { type, command, ... } }
+              // 2. Wrapped: { "mcpServers": { "server-name": { type, command, ... } } }
+              const unwrapped = (external.mcpServers && typeof external.mcpServers === 'object')
+                ? external.mcpServers as Record<string, MCPServerConfig>
+                : external as Record<string, MCPServerConfig>;
+              pluginServers = unwrapped;
+            }
           } else if (typeof pluginJson.mcpServers === 'object' && pluginJson.mcpServers !== null) {
             pluginServers = pluginJson.mcpServers;
           }
 
           for (const [name, config] of Object.entries(pluginServers)) {
+            const cfg = config as unknown as Record<string, unknown>;
+            // Set cwd for stdio servers so relative paths resolve from the plugin directory
+            if (cfg.type === 'stdio' || cfg.type === 'local' || !cfg.type) {
+              if (!cfg.cwd) {
+                cfg.cwd = pluginPath;
+              }
+            }
+            // Ensure tools field exists (SDK requires it)
+            if (!config.tools) {
+              config.tools = ['*'];
+            }
             servers[name] = config;
             diagnostics.push(`  ✅ ${name} ← plugin (${catalog}/${plugin})`);
           }


### PR DESCRIPTION
## Summary

Fix three bugs in plugin MCP discovery that caused MSX-MCP and WorkIQ to silently fail when discovered from installed Copilot CLI plugins.

## Root Causes

### 1. Wrapped JSON not unwrapped
Plugin `.mcp.json` files have a nested format:
```json
{ "mcpServers": { "msx-mcp": { "type": "stdio", "command": "node", "args": ["scripts/bootstrap.mjs"] } } }
```
But `readJson()` returned the whole object and the code assigned it directly — storing the wrapper under key `"mcpServers"` with `type: undefined` instead of unwrapping to get the actual server configs.

**Fix:** Check if the loaded JSON has a `mcpServers` key and unwrap it.

### 2. No CWD for stdio servers
Plugin configs use relative paths like `node scripts/bootstrap.mjs` but no `cwd` was set on the server config, so the SDK/CLI couldn't find the script when spawning the process.

**Fix:** Set `cwd` to the plugin's directory path for all stdio/local servers discovered from plugins.

### 3. Missing `tools` field
The SDK requires `tools: string[]` on every MCP server config, but plugin `.mcp.json` files often omit it.

**Fix:** Default to `tools: ["*"]` if the field is missing.

## Before/After

```
BEFORE (what SDK received):
  mcpServers: type=undefined  ← malformed wrapper object
  (msx-mcp: missing)
  (workiq: missing)

AFTER:
  msx-mcp:  type=stdio  cwd=~/.copilot/.../mcaps-microsoft--MSX-MCP  cmd=node
  workiq:   type=default cwd=~/.copilot/.../mcaps-microsoft--SPT-IQ   cmd=npx
  fabric:   type=http    headers=[Authorization]
```

## Testing

128 tests pass. Verified via debug logging that all 3 servers now appear in the SDK session config with correct types, CWDs, and tool lists.
