### PR TITLE
fix(test): increase timeout for flaky MCP override test in CI

### DIFF
--- a/packages/wingman/src/__tests__/mcp.test.ts
+++ b/packages/wingman/src/__tests__/mcp.test.ts
@@ -52,7 +52,7 @@ describe('discoverMCPServers', () => {
       },
     });
     expect(servers['powerbi-remote'].url).toBe('https://custom.example.com/mcp');
-  });
+  }, 15_000);
 });
 
 describe('discoverWithDiagnostics', () => {


### PR DESCRIPTION
## Summary

Fix flaky CI failure on `main` where the MCP override test timed out on Node 22.

## Changes

- Increased timeout for `user overrides replace built-in defaults with same name` test from default 5s to 15s
- Root cause: the test probes an unreachable HTTP URL (`custom.example.com`) for OAuth discovery, which can exceed 5s in CI environments

## Testing

- All 158 tests pass locally (130 core + 28 react)
- The test was timing out only on Node 22 in GitHub Actions, not locally or on Node 20

## Cleanup

Also deleted 2 stale remote branches (`docs/oauth-auth`, `feat/rpc-controls`) and pruned 7 remote tracking refs from previously merged PRs.
