### PR TITLE
feat(create-wingman-app): implement project scaffolding

### DIFF
--- a/.changeset/implement-create-wingman-app.md
+++ b/.changeset/implement-create-wingman-app.md
@@ -1,0 +1,5 @@
+---
+'create-wingman-app': minor
+---
+
+Implement project scaffolding — `npx create-wingman-app my-app` now generates a working Wingman chat application with `package.json`, `src/server.ts`, `tsconfig.json`, and `.gitignore`.

--- a/README.md
+++ b/README.md
@@ -65,13 +65,11 @@ export default defineConfig({
 
 ### Create a new app
 
-> **Note:** `create-wingman-app` is not yet implemented. For now, clone the repo directly:
-
 ```bash
-git clone https://github.com/ericchansen/wingman.git
-cd wingman
-pnpm install
-pnpm dev
+npx create-wingman-app my-app
+cd my-app
+npm install
+npm run dev
 ```
 
 Open `http://localhost:3000` — you have a working chat.
@@ -103,8 +101,8 @@ export default defineConfig({
   // MCP servers (merged with auto-discovered servers)
   mcpServers: {},
 
-  // Custom tools
-  tools: ['./src/tools/*.ts'],
+  // Custom tools (Tool[] from @github/copilot-sdk)
+  tools: [],
 
   // UI
   ui: {

--- a/packages/create-wingman-app/src/index.ts
+++ b/packages/create-wingman-app/src/index.ts
@@ -1,15 +1,147 @@
 #!/usr/bin/env node
 
-/**
- * create-wingman-app — Scaffold a new Wingman chat application.
- *
- * Usage:
- *   npx create-wingman-app my-chat
- *   npx create-wingman-app my-chat --template minimal
- */
+import fs from 'node:fs';
+import path from 'node:path';
+import prompts from 'prompts';
+import pc from 'picocolors';
 
-console.log('🛩️  create-wingman-app — coming soon');
-console.log('');
-console.log('In the meantime, clone the repo:');
-console.log('  git clone https://github.com/ericchansen/wingman.git');
-console.log('  cd wingman && pnpm install && pnpm dev');
+const args = process.argv.slice(2);
+const projectArg = args.find((a) => !a.startsWith('-'));
+
+function toTitle(name: string): string {
+  return name
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+async function main() {
+  console.log();
+  console.log(pc.bold('🛩️  create-wingman-app'));
+  console.log();
+
+  const response = await prompts(
+    [
+      {
+        type: projectArg ? null : 'text',
+        name: 'name',
+        message: 'Project name',
+        initial: 'my-wingman-app',
+      },
+      {
+        type: 'text',
+        name: 'title',
+        message: 'Chat UI title',
+        initial: (_: unknown, values: Record<string, string>) =>
+          toTitle(values.name ?? projectArg ?? 'My Wingman App'),
+      },
+      {
+        type: 'text',
+        name: 'systemPrompt',
+        message: 'System prompt',
+        initial: 'You are a helpful assistant.',
+      },
+    ],
+    {
+      onCancel: () => {
+        console.log(pc.red('Cancelled.'));
+        process.exit(1);
+      },
+    },
+  );
+
+  const name: string = projectArg ?? response.name;
+  const title: string = response.title;
+  const systemPrompt: string = response.systemPrompt;
+  const dir = path.resolve(process.cwd(), name);
+
+  if (fs.existsSync(dir)) {
+    console.log(pc.red(`\n  Directory "${name}" already exists.\n`));
+    process.exit(1);
+  }
+
+  fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+
+  // package.json
+  const pkg = {
+    name,
+    version: '0.1.0',
+    private: true,
+    type: 'module',
+    scripts: {
+      dev: 'tsx src/server.ts',
+      build: 'tsc',
+      start: 'node dist/server.js',
+    },
+    dependencies: {
+      '@wingmanjs/core': '^0.2.1',
+    },
+    devDependencies: {
+      '@types/node': '^22.0.0',
+      tsx: '^4.0.0',
+      typescript: '^5.7.0',
+    },
+  };
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify(pkg, null, 2) + '\n',
+  );
+
+  // src/server.ts
+  const serverTs = `import { startServer, defineConfig } from '@wingmanjs/core';
+
+const config = defineConfig({
+  systemPrompt: ${JSON.stringify(systemPrompt)},
+  server: { port: 3000 },
+  ui: {
+    title: ${JSON.stringify(title)},
+    welcomeMessage: 'How can I help you today?',
+  },
+});
+
+await startServer({ config });
+`;
+  fs.writeFileSync(path.join(dir, 'src', 'server.ts'), serverTs);
+
+  // tsconfig.json
+  const tsconfig = {
+    compilerOptions: {
+      target: 'ES2022',
+      module: 'ESNext',
+      moduleResolution: 'bundler',
+      strict: true,
+      esModuleInterop: true,
+      skipLibCheck: true,
+      outDir: './dist',
+      rootDir: './src',
+      declaration: true,
+    },
+    include: ['src/**/*'],
+  };
+  fs.writeFileSync(
+    path.join(dir, 'tsconfig.json'),
+    JSON.stringify(tsconfig, null, 2) + '\n',
+  );
+
+  // .gitignore
+  fs.writeFileSync(
+    path.join(dir, '.gitignore'),
+    'node_modules/\ndist/\n.env\n',
+  );
+
+  console.log();
+  console.log(pc.green(`  ✅ Created ${pc.bold(name)}`));
+  console.log();
+  console.log(`  ${pc.cyan('cd')} ${name}`);
+  console.log(`  ${pc.cyan('npm install')}`);
+  console.log(`  ${pc.cyan('npm run dev')}`);
+  console.log();
+  console.log(
+    `  Open ${pc.underline('http://localhost:3000')} — happy chatting! 🛩️`,
+  );
+  console.log();
+}
+
+main().catch((err) => {
+  console.error(pc.red('Error:'), err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Implements the `create-wingman-app` CLI scaffolding tool and fixes the README tools config bug.

**Closes #28** — `npx create-wingman-app my-app` now generates a working Wingman chat application
**Closes #30** — Replaces misleading `tools: ['./src/tools/*.ts']` glob pattern with correct `tools: []`

## Changes

### `packages/create-wingman-app/src/index.ts` (rewrite)
- Interactive CLI that prompts for project name, UI title, and system prompt
- Generates `package.json`, `src/server.ts`, `tsconfig.json`, `.gitignore`
- Uses `prompts` and `picocolors` (already installed as dependencies)
- Prints colorized next steps after scaffolding
- Handles edge cases: existing directory check, cancel handling, CLI arg parsing

### `README.md`
- Fixed tools config: `tools: ['./src/tools/*.ts']` → `tools: []` (the field accepts `Tool[]` from `@github/copilot-sdk`, not file path globs)
- Updated Quick Start: replaced "not yet implemented" clone instructions with `npx create-wingman-app` usage

### `.changeset/implement-create-wingman-app.md`
- Minor version bump for `create-wingman-app` (0.1.0 → 0.2.0)

## Testing

- All 158 tests pass (130 core + 28 react)
- E2E verified: ran CLI locally, generated project with correct file contents
- Build succeeds across all 4 packages
