### PR TITLE
docs: add getting-started guide, configuration reference, and example README

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,12 +223,20 @@ Quick config:
 
 ```typescript
 export default defineConfig({
-  // 'inject' (default) — read CLI cache + az fallback, inject Authorization header
+  // 'oauth' (default) — standalone OAuth 2.0 PKCE, works without Copilot CLI
   // 'cli' — let the SDK subprocess handle auth (requires interactive terminal)
+  // 'inject' — use az CLI token (metadata-only access)
   // 'none' — no auth injection
-  fabricAuth: 'inject',
+  fabricAuth: 'oauth',
 });
 ```
+
+## Documentation
+
+- [Getting Started](docs/getting-started.md) — create and run your first Wingman app
+- [Configuration Reference](docs/configuration.md) — all config options with types, defaults, and examples
+- [MCP Authentication](docs/mcp-auth.md) — OAuth setup for Fabric/Power BI and other protected MCP servers
+- [hello-wingman example](examples/hello-wingman/) — minimal 20-line example
 
 ## Contributing
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,437 @@
+# Configuration Reference
+
+Wingman is configured via `defineConfig()` — a type-safe helper that provides autocomplete and validation.
+
+```typescript
+import { startServer, defineConfig } from '@wingmanjs/core';
+
+const config = defineConfig({
+  // ...options
+});
+
+await startServer({ config });
+```
+
+All options are optional. Wingman ships with sensible defaults for everything.
+
+---
+
+## Agent behavior
+
+### `systemPrompt`
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Default** | `'You are a helpful assistant.'` |
+
+The system prompt sent to the model at the start of every conversation. This defines the AI's personality, capabilities, and constraints.
+
+```typescript
+defineConfig({
+  systemPrompt: 'You are a sales intelligence assistant. Always cite data sources.',
+});
+```
+
+### `model`
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Default** | `'claude-sonnet-4'` |
+
+The default model to use. Users can switch models from the UI if `showModelPicker` is enabled.
+
+```typescript
+defineConfig({
+  model: 'gpt-4.1',
+});
+```
+
+### `reasoningEffort`
+
+| | |
+|---|---|
+| **Type** | `'low' \| 'medium' \| 'high' \| 'xhigh'` |
+| **Default** | `'medium'` |
+
+Controls how much "thinking" the model does before responding. Higher values produce more thorough responses but use more tokens.
+
+```typescript
+defineConfig({
+  reasoningEffort: 'high',
+});
+```
+
+---
+
+## MCP servers
+
+### `mcpServers`
+
+| | |
+|---|---|
+| **Type** | `Record<string, MCPServerConfig>` |
+| **Default** | `{}` |
+
+Manually configured MCP servers. These are merged with auto-discovered servers from Copilot CLI plugins. If both define a server with the same name, the manual config takes precedence.
+
+Each server is either `stdio` (runs a local process) or `http` (connects to a remote URL):
+
+```typescript
+defineConfig({
+  mcpServers: {
+    // stdio — runs a local command
+    'my-database': {
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', '@my-org/db-mcp-server'],
+      env: { DB_URL: 'postgresql://localhost:5432/mydb' },
+      tools: ['*'],
+    },
+    // http — connects to a remote server
+    'my-api': {
+      type: 'http',
+      url: 'https://api.example.com/mcp',
+      headers: { 'X-Api-Key': process.env.API_KEY! },
+      tools: ['*'],
+    },
+  },
+});
+```
+
+#### `MCPStdioConfig`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `'stdio'` | ✅ | Server transport type |
+| `command` | `string` | ✅ | Command to run |
+| `args` | `string[]` | — | Command arguments |
+| `env` | `Record<string, string>` | — | Environment variables |
+| `tools` | `string[]` | ✅ | Tool names to enable (`['*']` for all) |
+
+#### `MCPHttpConfig`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `'http'` | ✅ | Server transport type |
+| `url` | `string` | ✅ | Server URL |
+| `headers` | `Record<string, string>` | — | HTTP headers |
+| `tools` | `string[]` | ✅ | Tool names to enable (`['*']` for all) |
+
+### `skillDirectories`
+
+| | |
+|---|---|
+| **Type** | `string[]` |
+| **Default** | `[]` |
+
+Paths to directories containing skill definitions for the Copilot SDK.
+
+```typescript
+defineConfig({
+  skillDirectories: ['./skills'],
+});
+```
+
+### `customAgents`
+
+| | |
+|---|---|
+| **Type** | `CustomAgentConfig[]` |
+| **Default** | `[]` |
+
+Custom agent configurations passed to the Copilot SDK.
+
+---
+
+## Tools
+
+### `tools`
+
+| | |
+|---|---|
+| **Type** | `Tool[]` (from `@github/copilot-sdk`) |
+| **Default** | `[]` |
+
+Custom tools to make available to the AI. Each tool defines a name, description, parameter schema, and an execute function.
+
+```typescript
+import type { Tool } from '@github/copilot-sdk';
+
+const myTool: Tool = {
+  name: 'lookup_customer',
+  description: 'Look up customer details by ID',
+  parameters: {
+    type: 'object',
+    properties: {
+      id: { type: 'string', description: 'Customer ID' },
+    },
+    required: ['id'],
+  },
+  execute: async ({ id }) => {
+    return await db.customers.findById(id);
+  },
+};
+
+defineConfig({
+  tools: [myTool],
+});
+```
+
+---
+
+## Authentication
+
+### `fabricAuth`
+
+| | |
+|---|---|
+| **Type** | `'oauth' \| 'cli' \| 'inject' \| 'none'` |
+| **Default** | `'oauth'` |
+
+How to authenticate to remote HTTP MCP servers (Fabric/Power BI, etc.):
+
+| Value | Description |
+|-------|-------------|
+| `'oauth'` | **(recommended)** Standalone OAuth 2.0 Authorization Code + PKCE. Probes each HTTP server for auth requirements, uses cached tokens, exposes `/api/auth/*` routes so users can sign in from the web UI. Works without the Copilot CLI installed. |
+| `'cli'` | Don't inject tokens — assume the Copilot CLI subprocess handles auth via its own browser OAuth flow. |
+| `'inject'` | Acquire a Fabric token via `az account get-access-token` and inject it as an Authorization header. Metadata-level access only (DAX ExecuteQuery fails with "Unauthorized"). |
+| `'none'` | No auth injection. Servers must be public or pre-authenticated. |
+
+See [MCP Authentication Guide](./mcp-auth.md) for detailed setup.
+
+---
+
+## UI
+
+### `ui.title`
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Default** | `'Wingman'` |
+
+The title displayed in the chat header.
+
+### `ui.theme`
+
+| | |
+|---|---|
+| **Type** | `'dark' \| 'light' \| 'system'` |
+| **Default** | `'system'` |
+
+Color theme. `'system'` follows the user's OS preference.
+
+### `ui.logo`
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Default** | `undefined` |
+
+Path or URL to a logo image displayed in the header.
+
+### `ui.welcomeMessage`
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Default** | `'How can I help?'` |
+
+Message shown in the chat area before any conversation starts.
+
+### `ui.suggestions`
+
+| | |
+|---|---|
+| **Type** | `string[]` |
+| **Default** | `[]` |
+
+Clickable suggestion chips shown below the welcome message.
+
+```typescript
+defineConfig({
+  ui: {
+    suggestions: ['Show my pipeline', 'Brief me on Contoso', 'Draft an email'],
+  },
+});
+```
+
+### `ui.colors`
+
+| | |
+|---|---|
+| **Type** | `Record<string, string>` |
+| **Default** | `{}` |
+
+Custom color overrides for the UI.
+
+### `ui.showTokenUsage`
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Default** | `true` |
+
+Show the live input/output token counter.
+
+### `ui.showModelPicker`
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Default** | `true` |
+
+Show the model switcher dropdown in the UI.
+
+### `ui.showModeSwitcher`
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Default** | `true` |
+
+Show the mode toggle (interactive / plan / autopilot).
+
+### `ui.showDebugPanel`
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Default** | `false` |
+
+Show the debug panel with raw event stream data.
+
+---
+
+## Server
+
+### `server.port`
+
+| | |
+|---|---|
+| **Type** | `number` |
+| **Default** | `3000` |
+
+The port the server listens on.
+
+### `server.cors`
+
+| | |
+|---|---|
+| **Type** | `boolean \| string \| string[]` |
+| **Default** | `true` |
+
+CORS configuration:
+- `true` — allow all origins (`*`). Fine for local dev, unsafe in production.
+- `false` — disable CORS headers entirely.
+- `string` — allow a single origin (e.g. `'https://myapp.com'`).
+- `string[]` — allow multiple specific origins.
+
+### `server.transport`
+
+| | |
+|---|---|
+| **Type** | `'sse' \| 'socketio'` |
+| **Default** | `'sse'` |
+
+Server transport protocol. SSE (Server-Sent Events) is the default and works in all modern browsers.
+
+---
+
+## Telemetry
+
+OpenTelemetry tracing is fully opt-in. When disabled (the default), there is zero overhead.
+
+### `telemetry.enabled`
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Default** | `false` |
+
+Enable OpenTelemetry tracing.
+
+### `telemetry.exporter`
+
+| | |
+|---|---|
+| **Type** | `'console' \| 'otlp'` |
+| **Default** | `'console'` |
+
+Where to send traces. Use `'otlp'` to send to Jaeger, Grafana Tempo, or other OTLP-compatible backends.
+
+### `telemetry.endpoint`
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Default** | `undefined` (uses `http://localhost:4318/v1/traces`) |
+
+OTLP endpoint URL. Only used when `exporter` is `'otlp'`.
+
+### `telemetry.serviceName`
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Default** | `'wingman'` |
+
+The `service.name` attribute in OpenTelemetry spans.
+
+### `telemetry.captureContent`
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Default** | `false` |
+
+Capture tool arguments and results in span attributes. Off by default because these may contain sensitive data.
+
+---
+
+## Full example
+
+```typescript
+import { startServer, defineConfig } from '@wingmanjs/core';
+
+const config = defineConfig({
+  systemPrompt: 'You are a helpful sales assistant.',
+  model: 'claude-sonnet-4',
+  reasoningEffort: 'high',
+
+  mcpServers: {
+    'sales-data': {
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', '@my-org/sales-mcp'],
+      tools: ['*'],
+    },
+  },
+
+  fabricAuth: 'oauth',
+
+  ui: {
+    title: 'Sales Assistant',
+    theme: 'dark',
+    welcomeMessage: 'Ready to help with your sales data!',
+    suggestions: ['Show my pipeline', 'Top deals this month'],
+    showTokenUsage: true,
+    showModelPicker: true,
+  },
+
+  server: {
+    port: 3000,
+    cors: true,
+  },
+
+  telemetry: {
+    enabled: true,
+    exporter: 'otlp',
+    endpoint: 'http://jaeger:4318/v1/traces',
+  },
+});
+
+await startServer({ config });
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,142 @@
+# Getting Started
+
+Build a chat application powered by [GitHub Copilot](https://github.com/features/copilot) in under a minute.
+
+## Prerequisites
+
+- **Node.js 20.11+** — [download](https://nodejs.org)
+- **GitHub Copilot access** — your GitHub account needs a Copilot subscription
+
+Optional:
+- [GitHub Copilot CLI](https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-in-the-command-line) — enables automatic MCP server discovery from installed plugins
+
+## Create a new app
+
+```bash
+npx create-wingman-app my-app
+```
+
+The CLI prompts for:
+1. **Project name** — directory to create (default: `my-wingman-app`)
+2. **Chat UI title** — displayed in the header
+3. **System prompt** — the AI's personality and instructions
+
+You can also pass the project name as an argument:
+
+```bash
+npx create-wingman-app sales-assistant
+```
+
+## Run it
+
+```bash
+cd my-app
+npm install
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) — you have a working chat.
+
+## Customize
+
+Edit `src/server.ts` to change any setting:
+
+```typescript
+import { startServer, defineConfig } from '@wingmanjs/core';
+
+const config = defineConfig({
+  systemPrompt: 'You are a sales intelligence assistant named Clippy...',
+  model: 'claude-sonnet-4',
+  server: { port: 3000 },
+  ui: {
+    title: 'Clippy Sales',
+    theme: 'dark',
+    welcomeMessage: "It looks like you're prepping for a meeting! 📎",
+    suggestions: ['Show my pipeline', 'Brief me on Contoso'],
+  },
+});
+
+await startServer({ config });
+```
+
+See [Configuration Reference](./configuration.md) for all available options.
+
+## Add MCP servers
+
+### Auto-discovery (recommended)
+
+If you have the GitHub Copilot CLI installed, Wingman automatically discovers MCP servers from your installed plugins:
+
+```bash
+copilot plugin install mcaps-microsoft/MSX-MCP
+copilot plugin install workiq@copilot-plugins
+```
+
+Restart your app — the servers are available immediately. No config needed.
+
+### Manual configuration
+
+Add servers directly in your config:
+
+```typescript
+const config = defineConfig({
+  mcpServers: {
+    'my-database': {
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', '@my-org/db-mcp-server'],
+      tools: ['*'],
+    },
+    'my-api': {
+      type: 'http',
+      url: 'https://api.example.com/mcp',
+      tools: ['*'],
+    },
+  },
+});
+```
+
+Manually configured servers are merged with auto-discovered ones. If both define a server with the same name, your manual config wins.
+
+## Add tools
+
+Pass SDK `Tool` objects to give the AI custom capabilities:
+
+```typescript
+import type { Tool } from '@github/copilot-sdk';
+
+const weatherTool: Tool = {
+  name: 'get_weather',
+  description: 'Get current weather for a city',
+  parameters: {
+    type: 'object',
+    properties: {
+      city: { type: 'string', description: 'City name' },
+    },
+    required: ['city'],
+  },
+  execute: async ({ city }) => {
+    const res = await fetch(`https://wttr.in/${city}?format=j1`);
+    return await res.json();
+  },
+};
+
+const config = defineConfig({
+  tools: [weatherTool],
+});
+```
+
+## Build for production
+
+```bash
+npm run build
+npm start
+```
+
+This compiles TypeScript to `dist/` and runs the compiled server with Node.js.
+
+## Next steps
+
+- [Configuration Reference](./configuration.md) — all config options with types, defaults, and examples
+- [MCP Authentication](./mcp-auth.md) — OAuth setup for Fabric/Power BI and other protected MCP servers
+- [Examples](../examples/hello-wingman/) — minimal working example

--- a/examples/hello-wingman/README.md
+++ b/examples/hello-wingman/README.md
@@ -1,0 +1,40 @@
+# hello-wingman
+
+Minimal Wingman chat application — ~20 lines of code.
+
+## What this does
+
+Starts a fully-featured chat server with the default configuration: Claude Sonnet model, SSE transport, auto-discovered MCP servers, and the built-in web UI on port 3000.
+
+## Run it
+
+From the monorepo root:
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Or run this example directly:
+
+```bash
+cd examples/hello-wingman
+npx tsx src/server.ts
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+## Customize
+
+Edit `src/server.ts` to change the system prompt, model, UI title, theme, or any other option. See the [Configuration Reference](../../docs/configuration.md) for all available settings.
+
+## Start from scratch
+
+Want your own standalone project (not in the monorepo)?
+
+```bash
+npx create-wingman-app my-app
+cd my-app
+npm install
+npm run dev
+```


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for new users.

**Closes #29**

## Changes

### `docs/getting-started.md` (new)
- Prerequisites, creating a new app with `create-wingman-app`, running it
- Customizing system prompt, model, UI
- Adding MCP servers (auto-discovery and manual config)
- Adding custom tools with the SDK `Tool` type
- Building for production

### `docs/configuration.md` (new)
- Full reference for every `WingmanConfig` option
- Organized by category: agent behavior, MCP servers, tools, auth, UI, server, telemetry
- Each option includes type, default value, description, and code example
- Tables for `MCPStdioConfig` and `MCPHttpConfig` fields
- Complete working example at the bottom

### `examples/hello-wingman/README.md` (new)
- What the example does, how to run it, what to customize
- Links to full docs and `create-wingman-app`

### `README.md` (updated)
- Added Documentation section with links to all guides
- Fixed stale `fabricAuth` comment (was showing `'inject'` as default, now correctly shows `'oauth'`)

## Testing

- Build passes across all 4 packages
- No code changes — documentation only
