### PR TITLE
feat(auth): group MCP servers by OAuth provider in connections panel

### DIFF
--- a/.changeset/auth-grouping.md
+++ b/.changeset/auth-grouping.md
@@ -1,0 +1,8 @@
+---
+'@wingmanjs/core': minor
+'@wingmanjs/react': minor
+---
+
+feat(auth): group MCP servers by OAuth provider in connections panel
+
+Servers requiring OAuth are now grouped by provider (e.g. "Microsoft", "Google", "GitHub") in the auth settings panel. Each group shows a "Sign in to all" button for batch authentication. The /api/auth/status endpoint returns both flat servers and grouped data.

--- a/packages/react/src/hooks/use-auth-status.ts
+++ b/packages/react/src/hooks/use-auth-status.ts
@@ -6,10 +6,14 @@ export interface McpAuthEntry {
   status: 'authenticated' | 'needs_auth' | 'no_auth_required' | 'error';
   expiresAt?: number;
   error?: string;
+  /** Provider label derived from the OAuth authorization endpoint (e.g., "Microsoft"). */
+  provider?: string;
 }
 
 interface AuthState {
   mcpAuth: McpAuthEntry[];
+  /** Servers grouped by provider (from API). */
+  groups: Record<string, McpAuthEntry[]>;
   loading: boolean;
   error: string | null;
   /** Servers currently going through OAuth flow. */
@@ -18,6 +22,8 @@ interface AuthState {
 
 export interface UseAuthStatusReturn {
   mcpAuth: McpAuthEntry[];
+  /** Servers grouped by provider (e.g., "Microsoft", "GitHub"). */
+  groups: Record<string, McpAuthEntry[]>;
   loading: boolean;
   error: string | null;
   pendingLogins: Set<string>;
@@ -39,6 +45,7 @@ export interface UseAuthStatusReturn {
 export function useAuthStatus(pollIntervalMs = 30_000, apiUrl = ''): UseAuthStatusReturn {
   const [state, setState] = useState<AuthState>({
     mcpAuth: [],
+    groups: {},
     loading: true,
     error: null,
     pendingLogins: new Set(),
@@ -56,6 +63,7 @@ export function useAuthStatus(pollIntervalMs = 30_000, apiUrl = ''): UseAuthStat
       setState((prev) => ({
         ...prev,
         mcpAuth: data.servers ?? [],
+        groups: data.groups ?? {},
         loading: false,
         error: null,
       }));
@@ -157,6 +165,7 @@ export function useAuthStatus(pollIntervalMs = 30_000, apiUrl = ''): UseAuthStat
 
   return {
     mcpAuth: state.mcpAuth,
+    groups: state.groups,
     loading: state.loading,
     error: state.error,
     pendingLogins: state.pendingLogins,

--- a/packages/wingman/src/auth/oauth-service.ts
+++ b/packages/wingman/src/auth/oauth-service.ts
@@ -59,7 +59,7 @@ export interface McpServerAuth {
   expiresAt?: number;
   error?: string;
   oauthConfig?: OAuthServerConfig | null;
-  /** Provider label derived from the OAuth authorization endpoint (e.g., "Microsoft 365"). */
+  /** Provider label derived from the OAuth authorization endpoint (e.g., "Microsoft"). */
   provider?: string;
 }
 

--- a/packages/wingman/src/auth/oauth-service.ts
+++ b/packages/wingman/src/auth/oauth-service.ts
@@ -59,6 +59,8 @@ export interface McpServerAuth {
   expiresAt?: number;
   error?: string;
   oauthConfig?: OAuthServerConfig | null;
+  /** Provider label derived from the OAuth authorization endpoint (e.g., "Microsoft 365"). */
+  provider?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/wingman/src/default-ui.ts
+++ b/packages/wingman/src/default-ui.ts
@@ -500,7 +500,7 @@ export function getDefaultHtml(ui: {
       if (groups && Object.keys(groups).length > 1) {
         const html = [];
         for (const [provider, list] of Object.entries(groups)) {
-          const label = provider === '__ungrouped__' ? 'Other' : provider.replace(/&/g,'&amp;').replace(/</g,'&lt;');
+          const label = provider === '__no_provider__' ? 'Other' : provider.replace(/&/g,'&amp;').replace(/</g,'&lt;');
           const groupNeeds = list.filter(s => s.status === 'needs_auth');
           html.push('<div class="auth-group">');
           html.push('<div class="auth-group-header">');
@@ -527,7 +527,7 @@ export function getDefaultHtml(ui: {
           btn.disabled = true;
           btn.textContent = 'Opening\\u2026';
           for (const url of urls) {
-            const serverBtn = panelBody.querySelector('.sign-in[data-url="' + url + '"]');
+            const serverBtn = Array.from(panelBody.querySelectorAll('.sign-in')).find(b => b.dataset.url === url);
             if (serverBtn) await handleSignIn(url, serverBtn);
           }
           btn.textContent = 'Sign in to all';

--- a/packages/wingman/src/default-ui.ts
+++ b/packages/wingman/src/default-ui.ts
@@ -147,6 +147,21 @@ export function getDefaultHtml(ui: {
     .server-action.sign-out:hover { background: var(--bg-secondary); }
     .server-action:disabled { opacity: .5; cursor: not-allowed; }
 
+    /* Auth provider groups */
+    .auth-group { margin-bottom: 16px; }
+    .auth-group-header {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 6px 0; margin-bottom: 6px;
+      border-bottom: 1px solid var(--border);
+    }
+    .auth-group-label {
+      font-size: 12px; font-weight: 600; text-transform: uppercase;
+      color: var(--text-secondary); letter-spacing: 0.05em;
+    }
+    .sign-in-all {
+      font-size: 11px; padding: 2px 10px;
+    }
+
     /* Overlay behind panel */
     #auth-overlay {
       position: fixed; inset: 0; background: rgba(0,0,0,.3);
@@ -441,7 +456,7 @@ export function getDefaultHtml(ui: {
       return 'Expires in ' + Math.round(mins / 60) + 'h';
     }
 
-    function renderServers(servers) {
+    function renderServers(servers, groups) {
       if (!servers || servers.length === 0) {
         panelBody.innerHTML = '<div class="panel-empty">No MCP servers configured.</div>';
         authBadge.classList.add('hidden');
@@ -455,7 +470,7 @@ export function getDefaultHtml(ui: {
         authBadge.classList.add('hidden');
       }
 
-      panelBody.innerHTML = servers.map(s => {
+      function renderCard(s) {
         const name = s.serverName.replace(/&/g,'&amp;').replace(/</g,'&lt;');
         const url = s.serverUrl.replace(/&/g,'&amp;').replace(/</g,'&lt;');
         const attrUrl = s.serverUrl.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
@@ -479,10 +494,45 @@ export function getDefaultHtml(ui: {
           + '<div class="server-url">' + url + '</div>'
           + action
           + '</div>';
-      }).join('');
+      }
 
-      panelBody.querySelectorAll('.sign-in').forEach(btn => {
+      // Render grouped if groups are provided, flat otherwise
+      if (groups && Object.keys(groups).length > 1) {
+        const html = [];
+        for (const [provider, list] of Object.entries(groups)) {
+          const label = provider === '__ungrouped__' ? 'Other' : provider.replace(/&/g,'&amp;').replace(/</g,'&lt;');
+          const groupNeeds = list.filter(s => s.status === 'needs_auth');
+          html.push('<div class="auth-group">');
+          html.push('<div class="auth-group-header">');
+          html.push('<span class="auth-group-label">' + label + ' (' + list.length + ')</span>');
+          if (groupNeeds.length > 1) {
+            const urls = groupNeeds.map(s => s.serverUrl.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;'));
+            html.push('<button class="server-action sign-in sign-in-all" data-urls=\\'' + JSON.stringify(urls) + '\\'>Sign in to all</button>');
+          }
+          html.push('</div>');
+          html.push(list.map(renderCard).join(''));
+          html.push('</div>');
+        }
+        panelBody.innerHTML = html.join('');
+      } else {
+        panelBody.innerHTML = servers.map(renderCard).join('');
+      }
+
+      panelBody.querySelectorAll('.sign-in:not(.sign-in-all)').forEach(btn => {
         btn.addEventListener('click', () => handleSignIn(btn.dataset.url, btn));
+      });
+      panelBody.querySelectorAll('.sign-in-all').forEach(btn => {
+        btn.addEventListener('click', async () => {
+          const urls = JSON.parse(btn.dataset.urls || '[]');
+          btn.disabled = true;
+          btn.textContent = 'Opening\\u2026';
+          for (const url of urls) {
+            const serverBtn = panelBody.querySelector('.sign-in[data-url="' + url + '"]');
+            if (serverBtn) await handleSignIn(url, serverBtn);
+          }
+          btn.textContent = 'Sign in to all';
+          btn.disabled = false;
+        });
       });
       panelBody.querySelectorAll('.sign-out').forEach(btn => {
         btn.addEventListener('click', () => handleSignOut(btn.dataset.url, btn));
@@ -498,7 +548,7 @@ export function getDefaultHtml(ui: {
           return;
         }
         const data = await res.json();
-        renderServers(data.servers || []);
+        renderServers(data.servers || [], data.groups);
       } catch (_) {
         panelBody.innerHTML = '<div class="panel-empty">Could not load auth status.</div>';
         authBadge.classList.add('hidden');

--- a/packages/wingman/src/mcp.ts
+++ b/packages/wingman/src/mcp.ts
@@ -217,6 +217,26 @@ const NEGATIVE_CACHE_TTL_MS = 60_000; // 60 seconds
 /** Track which HTTP servers need auth so the server layer can expose login routes. */
 let _lastAuthStatus: McpServerAuth[] = [];
 
+/**
+ * Derive a user-friendly provider label from an OAuth authorization endpoint.
+ * Groups servers that share the same identity provider under one label.
+ */
+function deriveProvider(authEndpoint: string | undefined): string | undefined {
+  if (!authEndpoint) return undefined;
+  try {
+    const host = new URL(authEndpoint).hostname.toLowerCase();
+    if (host.includes('login.microsoftonline.com') || host.includes('login.microsoft.com')) {
+      return 'Microsoft';
+    }
+    if (host.includes('accounts.google.com')) return 'Google';
+    if (host.includes('github.com')) return 'GitHub';
+    // Return the domain as a fallback provider label
+    return host.replace(/^(login|auth|accounts|id)\./i, '').replace(/\.(com|io|org|net)$/i, '');
+  } catch {
+    return undefined;
+  }
+}
+
 /** Get the auth status from the most recent discovery run. */
 export function getHttpServerAuthStatus(): McpServerAuth[] {
   return _lastAuthStatus;
@@ -409,6 +429,7 @@ async function injectOAuthHeaders(
           serverName: name,
           status: 'needs_auth',
           oauthConfig,
+          provider: deriveProvider(oauthConfig.authorizationEndpoint),
         });
         console.log(`  🔓 ${name} — needs sign-in (OAuth required)`);
       } else {

--- a/packages/wingman/src/mcp.ts
+++ b/packages/wingman/src/mcp.ts
@@ -217,6 +217,9 @@ const NEGATIVE_CACHE_TTL_MS = 60_000; // 60 seconds
 /** Track which HTTP servers need auth so the server layer can expose login routes. */
 let _lastAuthStatus: McpServerAuth[] = [];
 
+/** Cache provider labels so authenticated entries retain their group after login. */
+const _providerCache = new Map<string, string>();
+
 /**
  * Derive a user-friendly provider label from an OAuth authorization endpoint.
  * Groups servers that share the same identity provider under one label.
@@ -415,6 +418,7 @@ async function injectOAuthHeaders(
           serverName: name,
           status: 'authenticated',
           expiresAt: token.expiresAt,
+          provider: _providerCache.get(config.url),
         });
         console.log(`  🔑 ${name} — authenticated (token cached)`);
         continue;
@@ -424,12 +428,14 @@ async function injectOAuthHeaders(
       const oauthConfig = await discoverAuthRequirements(config.url);
       if (oauthConfig) {
         // Server requires OAuth and we don't have a token
+        const provider = deriveProvider(oauthConfig.authorizationEndpoint);
+        if (provider) _providerCache.set(config.url, provider);
         authStatus.push({
           serverUrl: config.url,
           serverName: name,
           status: 'needs_auth',
           oauthConfig,
-          provider: deriveProvider(oauthConfig.authorizationEndpoint),
+          provider,
         });
         console.log(`  🔓 ${name} — needs sign-in (OAuth required)`);
       } else {

--- a/packages/wingman/src/server.ts
+++ b/packages/wingman/src/server.ts
@@ -240,10 +240,11 @@ export function createServer(options: CreateServerOptions = {}): ServerInstance 
   app.get('/api/auth/status', (_req, res) => {
     const servers = getHttpServerAuthStatus();
 
-    // Group servers by provider for higher-level auth UX
+    // Group servers by provider for higher-level auth UX.
+    // Servers without a known provider go into the "__no_provider__" bucket.
     const groups: Record<string, typeof servers> = {};
     for (const s of servers) {
-      const key = s.provider ?? '__ungrouped__';
+      const key = s.provider ?? '__no_provider__';
       (groups[key] ??= []).push(s);
     }
 

--- a/packages/wingman/src/server.ts
+++ b/packages/wingman/src/server.ts
@@ -238,7 +238,16 @@ export function createServer(options: CreateServerOptions = {}): ServerInstance 
 
   /** Auth status for HTTP MCP servers (token health, which need login). */
   app.get('/api/auth/status', (_req, res) => {
-    res.json({ servers: getHttpServerAuthStatus() });
+    const servers = getHttpServerAuthStatus();
+
+    // Group servers by provider for higher-level auth UX
+    const groups: Record<string, typeof servers> = {};
+    for (const s of servers) {
+      const key = s.provider ?? '__ungrouped__';
+      (groups[key] ??= []).push(s);
+    }
+
+    res.json({ servers, groups });
   });
 
   /** Start OAuth flow for a remote MCP server. Returns the auth URL. */


### PR DESCRIPTION
## Summary

Groups MCP servers by OAuth provider in the connections panel, making it much easier to manage auth when you have many servers from the same provider (e.g. 8 Microsoft servers).

Closes #44

## Changes

### Core (`@wingmanjs/core`)
- **`mcp.ts`**: Added `deriveProvider()` function that maps OAuth authorization endpoint domains to friendly labels ("Microsoft", "Google", "GitHub", or cleaned domain fallback). Tags `needs_auth` entries with `provider` during discovery.
- **`oauth-service.ts`**: Added optional `provider` field to `McpServerAuth` interface.
- **`server.ts`**: Enhanced `GET /api/auth/status` to return `{ servers, groups }` — groups keyed by provider name, with `__ungrouped__` for servers that don't need auth.
- **`default-ui.ts`**: Updated `renderServers()` to render grouped layout with provider headers (e.g. "MICROSOFT (8)"), "Sign in to all" buttons, and CSS for `.auth-group` styling.

### React (`@wingmanjs/react`)
- **`use-auth-status.ts`**: Added `provider` to `McpAuthEntry`, `groups` to `AuthState` and `UseAuthStatusReturn`, parses groups from API response.

## UI Preview

The connections panel now shows:
- **Provider headers** with server count (e.g. "MICROSOFT (8)")
- **"Sign in to all"** button per provider group for batch authentication
- **"Other"** group for servers that don't require auth
- Falls back to flat list when only one group exists

## Testing

- All 158 tests pass (130 core + 28 react)
- Browser-verified: grouped panel renders correctly with provider headers, sign-in buttons, and "Other" section
- XSS protection: provider labels are HTML-escaped in client-side rendering
