### PR TITLE
feat(auth): add openAuthUrl option for desktop/Electron OAuth flows

### DIFF
--- a/.changeset/desktop-auth-launch.md
+++ b/.changeset/desktop-auth-launch.md
@@ -1,0 +1,7 @@
+---
+'@wingmanjs/react': minor
+---
+
+feat(auth): add openAuthUrl option for desktop/Electron OAuth flows
+
+The useAuthStatus hook now accepts an optional openAuthUrl function for launching OAuth URLs in the system browser instead of window.open(). Desktop/Electron apps can pass shell.openExternal to use the user's default browser profile for sign-in.

--- a/packages/react/src/hooks/use-auth-status.ts
+++ b/packages/react/src/hooks/use-auth-status.ts
@@ -20,6 +20,24 @@ interface AuthState {
   pendingLogins: Set<string>;
 }
 
+export interface UseAuthStatusOptions {
+  /**
+   * Custom function to open auth URLs.
+   *
+   * By default, the hook uses `window.open()` to launch a browser popup.
+   * Desktop / Electron apps should pass `shell.openExternal` (or a wrapper)
+   * so sign-in opens in the user's default system browser with their existing
+   * profile, saved passwords, and SSO session.
+   *
+   * @example
+   * ```ts
+   * import { shell } from 'electron';
+   * useAuthStatus(30_000, '', { openAuthUrl: (url) => shell.openExternal(url) });
+   * ```
+   */
+  openAuthUrl?: (url: string) => void | Promise<void>;
+}
+
 export interface UseAuthStatusReturn {
   mcpAuth: McpAuthEntry[];
   /** Servers grouped by provider (e.g., "Microsoft", "GitHub"). */
@@ -43,8 +61,13 @@ export interface UseAuthStatusReturn {
  *
  * @param pollIntervalMs - How often to poll for auth status (default: 30000)
  * @param apiUrl - Base URL for the API (default: '')
+ * @param options - Additional options (e.g. custom auth URL launcher for desktop apps)
  */
-export function useAuthStatus(pollIntervalMs = 30_000, apiUrl = ''): UseAuthStatusReturn {
+export function useAuthStatus(
+  pollIntervalMs = 30_000,
+  apiUrl = '',
+  options?: UseAuthStatusOptions,
+): UseAuthStatusReturn {
   const [state, setState] = useState<AuthState>({
     mcpAuth: [],
     groups: {},
@@ -55,6 +78,8 @@ export function useAuthStatus(pollIntervalMs = 30_000, apiUrl = ''): UseAuthStat
 
   const pendingLoginsRef = useRef(new Set<string>());
   const abortControllersRef = useRef(new Map<string, AbortController>());
+  const openAuthUrlRef = useRef(options?.openAuthUrl);
+  openAuthUrlRef.current = options?.openAuthUrl;
 
   // Abort any in-flight long-poll requests on unmount to avoid leaks
   useEffect(() => {
@@ -108,11 +133,15 @@ export function useAuthStatus(pollIntervalMs = 30_000, apiUrl = ''): UseAuthStat
       pendingLogins: new Set(pendingLoginsRef.current),
     }));
 
-    // Open a blank window immediately (synchronous with user gesture)
-    // to avoid popup blockers, then redirect once we have the auth URL.
-    // Avoid 'noopener' here so we retain a window reference for close detection.
-    const authWindow = window.open('about:blank', '_blank');
-    if (authWindow) authWindow.opener = null; // prevent reverse-tabnabbing
+    // Only pre-open a blank popup when using the default browser flow.
+    // Desktop apps with a custom opener skip this entirely.
+    // Read the ref at the last moment so hot-swapping the callback works.
+    let authWindow: Window | null = null;
+    if (!openAuthUrlRef.current) {
+      // Avoid 'noopener' here so we retain a window reference for close detection.
+      authWindow = window.open('about:blank', '_blank');
+      if (authWindow) authWindow.opener = null; // prevent reverse-tabnabbing
+    }
 
     try {
       // Request auth URL from backend
@@ -129,8 +158,13 @@ export function useAuthStatus(pollIntervalMs = 30_000, apiUrl = ''): UseAuthStat
 
       const { authUrl, state: flowState } = await res.json();
 
-      // Redirect the pre-opened window to the auth URL
-      if (authWindow) {
+      // Re-read the ref so we always use the latest callback
+      const opener = openAuthUrlRef.current;
+      if (opener) {
+        // Desktop/Electron: launch in system browser
+        await opener(authUrl);
+      } else if (authWindow) {
+        // Browser: redirect the pre-opened popup
         authWindow.location.href = authUrl;
       } else {
         // Fallback if window was blocked

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -12,7 +12,7 @@ export type { ChatProviderProps, ChatState, ChatContextValue } from './providers
 export { useAutoScroll } from './hooks/use-auto-scroll.js';
 
 export { useAuthStatus } from './hooks/use-auth-status.js';
-export type { McpAuthEntry, UseAuthStatusReturn } from './hooks/use-auth-status.js';
+export type { McpAuthEntry, UseAuthStatusOptions, UseAuthStatusReturn } from './hooks/use-auth-status.js';
 
 export { useChatHistory, formatRelativeDate } from './hooks/use-chat-history.js';
 export type { ChatSession, UseChatHistoryReturn } from './hooks/use-chat-history.js';


### PR DESCRIPTION
## Summary

Adds an `openAuthUrl` option to the `useAuthStatus` React hook, enabling desktop/Electron apps to launch OAuth sign-in in the user's system browser instead of a `window.open()` popup.

Closes #43

## Problem

`window.open()` inside Electron opens an in-app popup without the user's browser profile, saved passwords, or SSO session — making enterprise sign-in painful. Users need auth to open in their default browser (Edge/Chrome) where they already have active sessions.

## Solution

New optional third parameter on `useAuthStatus`:

```tsx
import { shell } from 'electron';

const { login } = useAuthStatus(30_000, '', {
  openAuthUrl: (url) => shell.openExternal(url),
});
```

When `openAuthUrl` is provided:
- Skips the `window.open('about:blank')` popup pre-opening
- Calls the custom function with the OAuth URL after fetching it from the backend
- Still long-polls `/api/auth/wait/:state` for the callback — works the same regardless of how the URL was opened

When omitted, behavior is unchanged (browser popup flow).

## Changes

### React (`@wingmanjs/react`)
- **`use-auth-status.ts`**: Added `UseAuthStatusOptions` interface with `openAuthUrl` callback. Updated `login()` to use custom opener when provided. Uses a ref to keep the callback stable across renders.
- **`index.ts`**: Export `UseAuthStatusOptions` type.

## Testing

- All 158 tests pass (130 core + 28 react)
- Browser-verified: default UI still loads correctly with sign-in buttons working
- Backward compatible: no changes to existing API surface
