### PR TITLE
feat(ui): Add session history sidebar to default chat UI

### DIFF
--- a/packages/wingman/src/__tests__/config.test.ts
+++ b/packages/wingman/src/__tests__/config.test.ts
@@ -32,7 +32,7 @@ describe('resolveConfig', () => {
     expect(resolved.systemPrompt).toBe(DEFAULT_CONFIG.systemPrompt);
     expect(resolved.model).toBe(DEFAULT_CONFIG.model);
     expect(resolved.ui.title).toBe('Wingman');
-    expect(resolved.ui.theme).toBe('system');
+    expect(resolved.ui.theme).toBe('dark');
     expect(resolved.ui.showTokenUsage).toBe(true);
     expect(resolved.ui.showModelPicker).toBe(true);
     expect(resolved.server.port).toBe(3000);
@@ -128,7 +128,7 @@ describe('DEFAULT_CONFIG', () => {
 
   it('has complete ui defaults', () => {
     expect(DEFAULT_CONFIG.ui.title).toBe('Wingman');
-    expect(DEFAULT_CONFIG.ui.theme).toBe('system');
+    expect(DEFAULT_CONFIG.ui.theme).toBe('dark');
     expect(DEFAULT_CONFIG.ui.welcomeMessage).toBe('How can I help?');
     expect(typeof DEFAULT_CONFIG.ui.showTokenUsage).toBe('boolean');
     expect(typeof DEFAULT_CONFIG.ui.showModelPicker).toBe('boolean');

--- a/packages/wingman/src/config.ts
+++ b/packages/wingman/src/config.ts
@@ -24,7 +24,7 @@ export const DEFAULT_CONFIG: Required<WingmanConfig> = {
   fabricAuth: 'oauth',
   ui: {
     title: 'Wingman',
-    theme: 'system',
+    theme: 'dark',
     logo: undefined,
     welcomeMessage: 'How can I help?',
     suggestions: [],

--- a/packages/wingman/src/default-ui.ts
+++ b/packages/wingman/src/default-ui.ts
@@ -17,7 +17,7 @@ export function getDefaultHtml(ui: {
   const welcome = esc(ui.welcomeMessage ?? 'How can I help?');
   const validThemes = ['dark', 'light', 'system'] as const;
   const theme = validThemes.includes(ui.theme as typeof validThemes[number])
-    ? ui.theme! : 'system';
+    ? ui.theme! : 'dark';
 
   return /* html */ `<!DOCTYPE html>
 <html lang="en" data-theme="${theme}">
@@ -53,7 +53,19 @@ export function getDefaultHtml(ui: {
     html, body { height: 100%; }
     body {
       font-family: var(--font); background: var(--bg); color: var(--text);
-      display: flex; flex-direction: column;
+      display: flex; flex-direction: row;
+    }
+
+    /* Persistent history sidebar */
+    #history-sidebar {
+      width: 260px; min-width: 260px; height: 100%;
+      background: var(--bg); border-right: 1px solid var(--border);
+      display: flex; flex-direction: column; flex-shrink: 0;
+    }
+
+    #main-content {
+      flex: 1; display: flex; flex-direction: column;
+      min-width: 0; height: 100%;
     }
 
     header {
@@ -65,6 +77,14 @@ export function getDefaultHtml(ui: {
     header h1 { font-size: 18px; font-weight: 600; }
     header { justify-content: flex-start; }
     .header-spacer { flex: 1; }
+
+    @media (max-width: 640px) {
+      body { flex-direction: column; }
+      #history-sidebar {
+        width: 100%; min-width: unset; height: auto; max-height: 40vh;
+        border-right: none; border-bottom: 1px solid var(--border);
+      }
+    }
 
     /* Auth settings button */
     #auth-btn {
@@ -169,6 +189,47 @@ export function getDefaultHtml(ui: {
     }
     #auth-overlay.open { display: block; }
 
+    /* History sidebar internals */
+    .sidebar-header {
+      padding: 16px 16px 12px; border-bottom: 1px solid var(--border);
+      display: flex; align-items: center; justify-content: space-between;
+    }
+    .sidebar-header h2 { font-size: 15px; font-weight: 600; }
+    #new-chat-btn {
+      margin: 10px 16px 6px; padding: 8px 12px; border-radius: 8px;
+      border: 1px dashed var(--border); background: none; color: var(--primary);
+      font-size: 13px; font-weight: 500; cursor: pointer; text-align: left;
+    }
+    #new-chat-btn:hover { background: var(--bg-secondary); border-style: solid; }
+    #session-list {
+      flex: 1; overflow-y: auto; padding: 6px 0;
+    }
+    .session-item {
+      display: flex; align-items: center; gap: 6px;
+      padding: 8px 16px; cursor: pointer; font-size: 13px;
+      border-left: 3px solid transparent;
+    }
+    .session-item:hover { background: var(--bg-secondary); }
+    .session-item.active { background: var(--bg-secondary); border-left-color: var(--primary); }
+    .session-item-content { flex: 1; min-width: 0; }
+    .session-title {
+      font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .session-date {
+      font-size: 11px; color: var(--text-secondary); margin-top: 2px;
+    }
+    .session-delete {
+      background: none; border: none; font-size: 14px; cursor: pointer;
+      color: var(--text-secondary); padding: 2px 4px; border-radius: 4px;
+      opacity: 0; transition: opacity .15s;
+    }
+    .session-item:hover .session-delete { opacity: 1; }
+    .session-delete:hover { color: #ef4444; background: var(--bg-secondary); }
+    .sidebar-empty {
+      text-align: center; color: var(--text-secondary); padding: 24px 16px;
+      font-size: 13px;
+    }
+
     #messages {
       flex: 1; overflow-y: auto; padding: 24px;
       display: flex; flex-direction: column; gap: 16px;
@@ -248,6 +309,17 @@ export function getDefaultHtml(ui: {
   </style>
 </head>
 <body>
+  <div id="history-sidebar">
+    <div class="sidebar-header">
+      <h2>Chat History</h2>
+    </div>
+    <button id="new-chat-btn">+ New chat</button>
+    <div id="session-list">
+      <div class="sidebar-empty">No conversations yet.</div>
+    </div>
+  </div>
+
+  <div id="main-content">
   <header>
     <span class="logo">🦜</span>
     <h1>${title}</h1>
@@ -337,6 +409,7 @@ export function getDefaultHtml(ui: {
       input.style.height = 'auto';
 
       addMessage('user', text);
+      chatMessages.push({ role: 'user', text: text });
 
       const assistantDiv = addMessage('assistant', '');
       assistantDiv.classList.add('typing');
@@ -400,6 +473,10 @@ export function getDefaultHtml(ui: {
         addMessage('error', 'Error: ' + err.message);
       } finally {
         assistantDiv.classList.remove('typing');
+        if (fullText) {
+          chatMessages.push({ role: 'assistant', text: fullText });
+        }
+        saveCurrentSession();
         busy = false;
         form.querySelector('button').disabled = false;
         input.focus();
@@ -407,6 +484,145 @@ export function getDefaultHtml(ui: {
     });
 
     input.focus();
+
+    // ── Session history logic ─────────────────────────────────────
+    const STORAGE_KEY = 'wingman-chat-history';
+    const MAX_SESSIONS = 50;
+    const newChatBtn = document.getElementById('new-chat-btn');
+    const sessionListEl = document.getElementById('session-list');
+
+    function loadSessions() {
+      try {
+        return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+      } catch (_) { return []; }
+    }
+
+    function saveSessions(list) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(list.slice(0, MAX_SESSIONS)));
+    }
+
+    let activeSessionKey = null;
+    let chatMessages = [];
+
+    function deriveTitle(text) {
+      const t = text.replace(/\\n/g, ' ').trim();
+      return t.length > 50 ? t.slice(0, 47) + '...' : t;
+    }
+
+    function formatDate(ts) {
+      const d = new Date(ts);
+      const now = new Date();
+      const diffMs = now - d;
+      const diffMins = Math.round(diffMs / 60000);
+      if (diffMins < 1) return 'Just now';
+      if (diffMins < 60) return diffMins + 'm ago';
+      const diffHrs = Math.round(diffMins / 60);
+      if (diffHrs < 24) return diffHrs + 'h ago';
+      const diffDays = Math.round(diffHrs / 24);
+      if (diffDays === 1) return 'Yesterday';
+      if (diffDays < 7) return diffDays + 'd ago';
+      return d.toLocaleDateString();
+    }
+
+    function saveCurrentSession() {
+      if (!activeSessionKey || chatMessages.length === 0) return;
+      const sessions = loadSessions();
+      const idx = sessions.findIndex(s => s.key === activeSessionKey);
+      const title = deriveTitle(
+        (chatMessages.find(m => m.role === 'user') || {}).text || 'New chat'
+      );
+      const entry = {
+        key: activeSessionKey,
+        serverSessionId: sessionId,
+        title: title,
+        messages: chatMessages,
+        updatedAt: Date.now(),
+        createdAt: idx >= 0 ? sessions[idx].createdAt : Date.now(),
+      };
+      if (idx >= 0) sessions.splice(idx, 1);
+      sessions.unshift(entry);
+      saveSessions(sessions);
+      renderSessionList();
+    }
+
+    function startNewChat() {
+      activeSessionKey = 'wm_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
+      sessionId = null;
+      chatMessages = [];
+      messages.innerHTML = '<div class="welcome"><h2>${welcome}</h2><p>Type a message below to get started.</p></div>';
+      input.focus();
+      renderSessionList();
+    }
+
+    function loadSession(key) {
+      const sessions = loadSessions();
+      const s = sessions.find(s => s.key === key);
+      if (!s) return;
+
+      activeSessionKey = s.key;
+      sessionId = s.serverSessionId || null;
+      chatMessages = s.messages || [];
+
+      messages.innerHTML = '';
+      for (const m of chatMessages) {
+        const div = document.createElement('div');
+        div.className = 'msg ' + m.role;
+        if (m.role === 'assistant') {
+          div.innerHTML = renderMarkdownLite(m.text);
+        } else {
+          div.textContent = m.text;
+        }
+        messages.appendChild(div);
+      }
+      messages.scrollTop = messages.scrollHeight;
+      input.focus();
+      renderSessionList();
+    }
+
+    function deleteSession(key) {
+      const sessions = loadSessions().filter(s => s.key !== key);
+      saveSessions(sessions);
+      if (activeSessionKey === key) startNewChat();
+      renderSessionList();
+    }
+
+    function renderSessionList() {
+      const sessions = loadSessions();
+      if (sessions.length === 0) {
+        sessionListEl.innerHTML = '<div class="sidebar-empty">No conversations yet.</div>';
+        return;
+      }
+      sessionListEl.innerHTML = sessions.map(s => {
+        const t = (s.title || 'New chat').replace(/&/g,'&amp;').replace(/</g,'&lt;');
+        const active = s.key === activeSessionKey ? ' active' : '';
+        return '<div class="session-item' + active + '" data-key="' + s.key + '">'
+          + '<div class="session-item-content">'
+          + '<div class="session-title">' + t + '</div>'
+          + '<div class="session-date">' + formatDate(s.updatedAt || s.createdAt) + '</div>'
+          + '</div>'
+          + '<button class="session-delete" data-key="' + s.key + '" aria-label="Delete session" title="Delete">&times;</button>'
+          + '</div>';
+      }).join('');
+
+      sessionListEl.querySelectorAll('.session-item').forEach(el => {
+        el.addEventListener('click', (e) => {
+          if (e.target.closest('.session-delete')) return;
+          loadSession(el.dataset.key);
+        });
+      });
+      sessionListEl.querySelectorAll('.session-delete').forEach(btn => {
+        btn.addEventListener('click', (e) => {
+          e.stopPropagation();
+          deleteSession(btn.dataset.key);
+        });
+      });
+    }
+
+    newChatBtn.addEventListener('click', () => startNewChat());
+
+    // Initialize
+    startNewChat();
+    renderSessionList();
 
     // ── Auth panel logic ──────────────────────────────────────────
     const authBtn = document.getElementById('auth-btn');
@@ -649,6 +865,7 @@ export function getDefaultHtml(ui: {
     // Fetch auth status on load to show badge
     fetchAuthStatus();
   </script>
+  </div><!-- /main-content -->
 </body>
 </html>`;
 }

--- a/packages/wingman/src/default-ui.ts
+++ b/packages/wingman/src/default-ui.ts
@@ -221,9 +221,10 @@ export function getDefaultHtml(ui: {
     .session-delete {
       background: none; border: none; font-size: 14px; cursor: pointer;
       color: var(--text-secondary); padding: 2px 4px; border-radius: 4px;
-      opacity: 0; transition: opacity .15s;
+      opacity: 0; pointer-events: none; transition: opacity .15s;
     }
-    .session-item:hover .session-delete { opacity: 1; }
+    .session-item:hover .session-delete,
+    .session-delete:focus-visible { opacity: 1; pointer-events: auto; }
     .session-delete:hover { color: #ef4444; background: var(--bg-secondary); }
     .sidebar-empty {
       text-align: center; color: var(--text-secondary); padding: 24px 16px;
@@ -313,7 +314,7 @@ export function getDefaultHtml(ui: {
     <div class="sidebar-header">
       <h2>Chat History</h2>
     </div>
-    <button id="new-chat-btn">+ New chat</button>
+    <button id="new-chat-btn" type="button">+ New chat</button>
     <div id="session-list">
       <div class="sidebar-empty">No conversations yet.</div>
     </div>
@@ -476,7 +477,7 @@ export function getDefaultHtml(ui: {
         if (fullText) {
           chatMessages.push({ role: 'assistant', text: fullText });
         }
-        saveCurrentSession();
+        try { saveCurrentSession(); } catch (_) { /* storage errors must not block UI reset */ }
         busy = false;
         form.querySelector('button').disabled = false;
         input.focus();
@@ -493,12 +494,15 @@ export function getDefaultHtml(ui: {
 
     function loadSessions() {
       try {
-        return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+        const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+        return Array.isArray(parsed) ? parsed : [];
       } catch (_) { return []; }
     }
 
     function saveSessions(list) {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(list.slice(0, MAX_SESSIONS)));
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(list.slice(0, MAX_SESSIONS)));
+      } catch (_) { /* quota exceeded or storage disabled — silently ignore */ }
     }
 
     let activeSessionKey = null;
@@ -592,28 +596,41 @@ export function getDefaultHtml(ui: {
         sessionListEl.innerHTML = '<div class="sidebar-empty">No conversations yet.</div>';
         return;
       }
-      sessionListEl.innerHTML = sessions.map(s => {
-        const t = (s.title || 'New chat').replace(/&/g,'&amp;').replace(/</g,'&lt;');
-        const active = s.key === activeSessionKey ? ' active' : '';
-        return '<div class="session-item' + active + '" data-key="' + s.key + '">'
-          + '<div class="session-item-content">'
-          + '<div class="session-title">' + t + '</div>'
-          + '<div class="session-date">' + formatDate(s.updatedAt || s.createdAt) + '</div>'
-          + '</div>'
-          + '<button class="session-delete" data-key="' + s.key + '" aria-label="Delete session" title="Delete">&times;</button>'
-          + '</div>';
-      }).join('');
+      sessionListEl.innerHTML = '';
+      sessions.forEach(s => {
+        const item = document.createElement('div');
+        item.className = 'session-item' + (s.key === activeSessionKey ? ' active' : '');
+        item.dataset.key = s.key;
 
-      sessionListEl.querySelectorAll('.session-item').forEach(el => {
-        el.addEventListener('click', (e) => {
+        const content = document.createElement('div');
+        content.className = 'session-item-content';
+        const titleEl = document.createElement('div');
+        titleEl.className = 'session-title';
+        titleEl.textContent = s.title || 'New chat';
+        const dateEl = document.createElement('div');
+        dateEl.className = 'session-date';
+        dateEl.textContent = formatDate(s.updatedAt || s.createdAt);
+        content.appendChild(titleEl);
+        content.appendChild(dateEl);
+
+        const del = document.createElement('button');
+        del.className = 'session-delete';
+        del.setAttribute('aria-label', 'Delete session');
+        del.title = 'Delete';
+        del.textContent = '\\u00d7';
+        del.type = 'button';
+
+        item.appendChild(content);
+        item.appendChild(del);
+        sessionListEl.appendChild(item);
+
+        item.addEventListener('click', (e) => {
           if (e.target.closest('.session-delete')) return;
-          loadSession(el.dataset.key);
+          loadSession(s.key);
         });
-      });
-      sessionListEl.querySelectorAll('.session-delete').forEach(btn => {
-        btn.addEventListener('click', (e) => {
+        del.addEventListener('click', (e) => {
           e.stopPropagation();
-          deleteSession(btn.dataset.key);
+          deleteSession(s.key);
         });
       });
     }
@@ -622,7 +639,6 @@ export function getDefaultHtml(ui: {
 
     // Initialize
     startNewChat();
-    renderSessionList();
 
     // ── Auth panel logic ──────────────────────────────────────────
     const authBtn = document.getElementById('auth-btn');


### PR DESCRIPTION
## Summary

Add a persistent session history sidebar to the default chat UI, and change the default theme to dark. Closes #39.

## Changes

- **Persistent sidebar** — always-visible left panel (260px) showing past conversations
- **localStorage-backed** — sessions saved/restored across page refreshes (max 50)
- **Session management** — new chat, restore, delete with hover-reveal delete button
- **Title derivation** — auto-titles from first user message (truncated at 50 chars)
- **Responsive** — collapses to horizontal top panel on mobile (<640px)
- **Dark mode default** — changed `DEFAULT_CONFIG.ui.theme` from `'system'` to `'dark'`
- **Server session linking** — restores `serverSessionId` for context continuity

## Files Changed

| File | Change |
|------|--------|
| `packages/wingman/src/default-ui.ts` | Sidebar HTML/CSS/JS, flex layout refactor, dark fallback |
| `packages/wingman/src/config.ts` | Default theme `'system'` → `'dark'` |
| `packages/wingman/src/__tests__/config.test.ts` | Updated 2 assertions to match new default |

## Testing

- All 130 tests pass (`npx turbo build test` — 6 tasks successful)
- Browser-verified: dark theme, sidebar visible, send → save → refresh → restore → delete
